### PR TITLE
Fix distributed_task_dispatcher_test.cc compile error

### DIFF
--- a/yadcc/daemon/local/distributed_task_dispatcher_test.cc
+++ b/yadcc/daemon/local/distributed_task_dispatcher_test.cc
@@ -57,7 +57,7 @@ class TestingTask : public DistributedTask {
   flare::Expected<std::uint64_t, flare::Status> StartTask(
       const std::string& token, std::uint64_t grant_id,
       cloud::DaemonService_SyncStub* stub) override {
-    return 10;
+    return static_cast<std::uint64_t>(10);
   }
   void OnCompletion(const DistributedTaskOutput& output) override {
     this->output = output;

--- a/yadcc/doc/usage.md
+++ b/yadcc/doc/usage.md
@@ -4,13 +4,13 @@
 
 编译完成后，至少需要启动如下服务：
 
-- 需要一台用于调度任务的机器，并运行`yadcc/scheduler/yadcc-scheduler`。具体使用可以参考[调度器文档](scheduler.md)。如：`./yadcc-scheduler --acceptable_tokens=some_fancy_token`。
+- 需要一台用于调度任务的机器，并运行`yadcc/scheduler/yadcc-scheduler`。具体使用可以参考[调度器文档](scheduler.md)。如：`./yadcc-scheduler --acceptable_user_tokens=some_fancy_token --acceptable_servant_tokens=some_fancy_token`。
 
   *尽管生产环境中不推荐，测试时调度机可以和编译机、用户机位于同一台机器。*
 
 为了加速编译（用户**之间**互相共享编译结果），还可以启动如下服务：
 
-- 缓存服务器上运行`yadcc/cache/yadcc-cache`。具体使用可以参考[缓存服务器文档](cache.md)。如：`./yadcc-cache --acceptable_tokens=some_fancy_token`。
+- 缓存服务器上运行`yadcc/cache/yadcc-cache`。具体使用可以参考[缓存服务器文档](cache.md)。如：`./yadcc-cache --acceptable_user_tokens=some_fancy_token --acceptable_servant_tokens=some_fancy_token`。
 
   *尽管生产环境中不推荐，测试时缓存服务器可以和调度器、编译机、用户机位于同一台机器。*
 
@@ -41,8 +41,8 @@
 #### 通过符号连接（blade、bazel、Makefile、...）
 
 1. 创建目录`~/.yadcc/bin`、`~/.yadcc/symlinks`。
-2. 复制`build64_release/yadcc/client/yadcc`至`~/.yadcc/bin`。
-3. 创建软链接`~/.yadcc/symlinks/{c++,g++,gcc}`至`~/.yadcc/bin/yadcc`。
+2. 复制`build64_release/yadcc/client/cxx/yadcc-cxx`至`~/.yadcc/bin`。
+3. 创建软链接`~/.yadcc/symlinks/{c++,g++,gcc}`至`~/.yadcc/bin/yadcc-cxx`。
 4. 将`~/.yadcc/symlinks`加入`PATH`的头部。
 
 执行完毕上述操作之后`which gcc`应当输出类似于`~/.yadcc/symlinks/gcc`的结果。


### PR DESCRIPTION
- I got the following error when compiling yadcc 2.0 (gcc 11.3 ubuntu 22.04), I made a small change and it should be solved:
  ```
  In file included from ./yadcc/daemon/local/distributed_task_dispatcher.h:26,                                                                                                           
                   from yadcc/daemon/local/distributed_task_dispatcher_test.cc:15:                                                                                                       
  ./flare/base/expected.h: In instantiation of 'constexpr flare::Expected<T, E>::Expected(U&&) [with U = int; <template-parameter-2-2> = void; T = long unsigned int; E = flare::Status]'
  :                                            
  yadcc/daemon/local/distributed_task_dispatcher_test.cc:61:16:   required from here                                                                                                     
  ./flare/base/expected.h:39:9: error: no matching function for call to 'std::variant<long unsigned int, flare::Status>::variant(int)'
     39 |       : value_(std::forward<U>(value)) {}                                          
        |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
  ```
- By the way, I also updated the usage.md, for example, `changing build64_release/yadcc/client/yadcc` to `build64_release/yadcc/client/cxx/yadcc-cxx`, and changing the scheduler and cache `--acceptable_ tokens=some_fancy_token ` to `--acceptable_user_tokens=some_fancy_token  --acceptable_servant_tokens=some_fancy_token `